### PR TITLE
Improve historial view layout

### DIFF
--- a/src/app/components/historial/historial.component.css
+++ b/src/app/components/historial/historial.component.css
@@ -145,6 +145,26 @@
   font-size: 22px;
 }
 
+.history-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.history-section .section-title {
+  margin-bottom: 12px;
+  font-size: 1.2rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  width: 100%;
+}
+
 @media (max-width: 600px) {
   .history-content {
     padding: 8px;

--- a/src/app/components/historial/historial.component.html
+++ b/src/app/components/historial/historial.component.html
@@ -7,29 +7,35 @@
   </mat-toolbar>
 
   <div class="history-content" *ngIf="!isLoading">
-    <div class="dashboard-section">
-      <h2>Tareas terminadas</h2>
-      <mat-card *ngFor="let t of tasksCompleted; trackBy: trackById" class="history-item-card">
-        <mat-card-title>{{ t.metadata?.taskTitle }}</mat-card-title>
-        <mat-card-subtitle>{{ t.timestamp | date:'medium' }}</mat-card-subtitle>
-        <mat-card-content>
-          <p>Duración: {{ t.metadata?.duration | formatTime }}</p>
-        </mat-card-content>
-      </mat-card>
-    </div>
+    <div class="history-sections">
+      <section class="history-section tasks-section">
+        <h2 class="section-title">Tareas terminadas</h2>
+        <div class="card-grid">
+          <mat-card *ngFor="let t of tasksCompleted; trackBy: trackById" class="history-item-card">
+            <mat-card-title>{{ t.metadata?.taskTitle }}</mat-card-title>
+            <mat-card-subtitle>{{ t.timestamp | date:'medium' }}</mat-card-subtitle>
+            <mat-card-content>
+              <p>Duración: {{ t.metadata?.duration | formatTime }}</p>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </section>
 
-    <div class="dashboard-section">
-      <h2>Hábitos activos</h2>
-      <mat-card *ngFor="let h of activeHabits" class="history-item-card">
-        <mat-card-title>{{ h.name }}</mat-card-title>
-        <app-progress-matrix
-          [progressData]="getYearProgress(h)"
-          [matrixColumns]="53"
-          [currentProgress]="getCurrentProgress(h)"
-          [totalProgress]="h.hasTarget ? h.targetCount || 0 : 0"
-          [habitFrequency]="h.type === 'quit' ? 'quit' : h.frequency">
-        </app-progress-matrix>
-      </mat-card>
+      <section class="history-section habits-section">
+        <h2 class="section-title">Hábitos activos</h2>
+        <div class="card-grid">
+          <mat-card *ngFor="let h of activeHabits" class="history-item-card">
+            <mat-card-title>{{ h.name }}</mat-card-title>
+            <app-progress-matrix
+              [progressData]="getYearProgress(h)"
+              [matrixColumns]="53"
+              [currentProgress]="getCurrentProgress(h)"
+              [totalProgress]="h.hasTarget ? h.targetCount || 0 : 0"
+              [habitFrequency]="h.type === 'quit' ? 'quit' : h.frequency">
+            </app-progress-matrix>
+          </mat-card>
+        </div>
+      </section>
     </div>
   </div>
 </div>

--- a/src/app/components/progress-matrix/progress-matrix.component.css
+++ b/src/app/components/progress-matrix/progress-matrix.component.css
@@ -2,7 +2,8 @@
   width: 100%;
   margin-top: 8px;
   position: relative;
-  overflow: none; /* CORRECCIÓN V30: Cambiar a overflow: none como solicitó el usuario */
+  overflow-x: auto; /* Allow horizontal scroll when needed */
+  --columns: 35;
 }
 
 .matrix-container {
@@ -11,12 +12,13 @@
   gap: 3px;
   position: relative;
   width: 100%;
+  min-width: calc(var(--columns) * 9px);
 }
 
 .matrix-row {
   display: flex;
   gap: 3px;
-  justify-content: space-around;
+  justify-content: flex-start;
   width: 100%;
 }
 

--- a/src/app/components/progress-matrix/progress-matrix.component.html
+++ b/src/app/components/progress-matrix/progress-matrix.component.html
@@ -1,4 +1,4 @@
-<div class="progress-matrix">
+<div class="progress-matrix" [style.--columns]="matrixColumns">
   <div class="matrix-container">
     <!-- Matriz uniforme de puntos para visualizar el progreso -->
     <div class="matrix-row" *ngFor="let row of matrixRows; let i = index">


### PR DESCRIPTION
## Summary
- make progress matrix width dynamic and horizontally scrollable
- restructure historial page layout using responsive card grid

## Testing
- `npm test` *(fails: cannot find tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_b_68456c714a08832eb417e23c62c5569f